### PR TITLE
Missing 'deep' argument

### DIFF
--- a/quapy/classification/methods.py
+++ b/quapy/classification/methods.py
@@ -21,14 +21,14 @@ class LowRankLogisticRegression(BaseEstimator):
         self.n_components = n_components
         self.learner = LogisticRegression(**kwargs)
 
-    def get_params(self):
+    def get_params(self, deep=True):
         """
         Get hyper-parameters for this estimator.
 
         :return: a dictionary with parameter names mapped to their values
         """
         params = {'n_components': self.n_components}
-        params.update(self.learner.get_params())
+        params.update(self.learner.get_params(deep))
         return params
 
     def set_params(self, **params):


### PR DESCRIPTION
https://github.com/HLT-ISTI/QuaPy/blob/140ab3bfc9a7cf398e49e601f1c1a16a9fdb8e5c/quapy/classification/methods.py#L24

get_params of LowRankLogisticRegression is missing the 'deep' argument from the BaseEstimator.

This causes an error when the code using the method uses the 'deep' argument, e.g., the 'cross_val_predict' function of sklearn, which clones using `deep=False`.

Given that this method only adds the single parameter of the wrapping class to the dict of parameters, I think that it is only required to add the argument to the method and pass it to the wrapped instance of LogisticRegression as is.
