### PR TITLE
Bayesian quantification prototype

### DIFF
--- a/quapy/functional.py
+++ b/quapy/functional.py
@@ -28,22 +28,34 @@ def prevalence_linspace(n_prevalences=21, repeats=1, smooth_limits_epsilon=0.01)
     return p
 
 
-def prevalence_from_labels(labels, classes):
+def counts_from_labels(labels, classes):
     """
-    Computed the prevalence values from a vector of labels.
+    Computes the count values from a vector of labels.
 
-    :param labels: array-like of shape `(n_instances)` with the label for each instance
+    :param labels: array-like of shape `(n_instances,)` with the label for each instance
     :param classes: the class labels. This is needed in order to correctly compute the prevalence vector even when
         some classes have no examples.
-    :return: an ndarray of shape `(len(classes))` with the class prevalence values
+    :return: an ndarray of shape `(len(classes),)` with the occurrence counts of each class
     """
     if labels.ndim != 1:
         raise ValueError(f'param labels does not seem to be a ndarray of label predictions')
     unique, counts = np.unique(labels, return_counts=True)
     by_class = defaultdict(lambda:0, dict(zip(unique, counts)))
-    prevalences = np.asarray([by_class[class_] for class_ in classes], dtype=float)
-    prevalences /= prevalences.sum()
-    return prevalences
+    counts = np.asarray([by_class[class_] for class_ in classes], dtype=int)
+    return counts
+
+
+def prevalence_from_labels(labels, classes):
+    """
+    Computes the prevalence values from a vector of labels.
+
+    :param labels: array-like of shape `(n_instances,)` with the label for each instance
+    :param classes: the class labels. This is needed in order to correctly compute the prevalence vector even when
+        some classes have no examples.
+    :return: an ndarray of shape `(len(classes))` with the class prevalence values
+    """
+    counts = np.array(counts_from_labels(labels, classes), dtype=float)
+    return counts / np.sum(counts)
 
 
 def prevalence_from_probabilities(posteriors, binarize: bool = False):

--- a/quapy/method/_bayesian.py
+++ b/quapy/method/_bayesian.py
@@ -1,0 +1,78 @@
+"""
+Utility functions for `Bayesian quantification <https://arxiv.org/abs/2302.09159>`_ methods.
+"""
+import numpy as np
+
+try:
+    import jax
+    import jax.numpy as jnp
+    import numpyro
+    import numpyro.distributions as dist
+
+    DEPENDENCIES_INSTALLED = True
+except ImportError:
+    jax = None
+    jnp = None
+    numpyro = None
+    dist = None
+
+    DEPENDENCIES_INSTALLED = False
+
+
+P_TEST_Y: str = "P_test(Y)"
+P_TEST_C: str = "P_test(C)"
+P_C_COND_Y: str = "P(C|Y)"
+
+
+def model(n_c_unlabeled: np.ndarray, n_y_and_c_labeled: np.ndarray) -> None:
+    """
+    Defines a probabilistic model in `NumPyro <https://num.pyro.ai/>`_.
+
+    :param n_c_unlabeled: a `np.ndarray` of shape `(n_predicted_classes,)`
+        with entry `c` being the number of instances predicted as class `c`.
+    :param n_y_and_c_labeled: a `np.ndarray` of shape `(n_classes, n_predicted_classes)`
+        with entry `(y, c)` being the number of instances labeled as class `y` and predicted as class `c`.
+    """
+    n_y_labeled = n_y_and_c_labeled.sum(axis=1)
+
+    K = len(n_c_unlabeled)
+    L = len(n_y_labeled)
+
+    pi_ = numpyro.sample(P_TEST_Y, dist.Dirichlet(jnp.ones(L)))
+    p_c_cond_y = numpyro.sample(P_C_COND_Y, dist.Dirichlet(jnp.ones(K).repeat(L).reshape(L, K)))
+
+    with numpyro.plate('plate', L):
+        numpyro.sample('F_yc', dist.Multinomial(n_y_labeled, p_c_cond_y), obs=n_y_and_c_labeled)
+
+    p_c = numpyro.deterministic(P_TEST_C, jnp.einsum("yc,y->c", p_c_cond_y, pi_))
+    numpyro.sample('N_c', dist.Multinomial(jnp.sum(n_c_unlabeled), p_c), obs=n_c_unlabeled)
+
+
+def sample_posterior(
+    n_c_unlabeled: np.ndarray,
+    n_y_and_c_labeled: np.ndarray,
+    num_warmup: int,
+    num_samples: int,
+    seed: int = 0,
+) -> dict:
+    """
+    Samples from the Bayesian quantification model in NumPyro using the
+    `NUTS <https://arxiv.org/abs/1111.4246>`_ sampler.
+
+    :param n_c_unlabeled: a `np.ndarray` of shape `(n_predicted_classes,)`
+        with entry `c` being the number of instances predicted as class `c`.
+    :param n_y_and_c_labeled: a `np.ndarray` of shape `(n_classes, n_predicted_classes)`
+        with entry `(y, c)` being the number of instances labeled as class `y` and predicted as class `c`.
+    :param num_warmup: the number of warmup steps.
+    :param num_samples: the number of samples to draw.
+    :seed: the random seed.
+    :return: a `dict` with the samples. The keys are the names of the latent variables.
+    """
+    mcmc = numpyro.infer.MCMC(
+        numpyro.infer.NUTS(model),
+        num_warmup=num_warmup,
+        num_samples=num_samples,
+    )
+    rng_key = jax.random.PRNGKey(seed)
+    mcmc.run(rng_key, n_c_unlabeled=n_c_unlabeled, n_y_and_c_labeled=n_y_and_c_labeled)
+    return mcmc.get_samples()

--- a/quapy/method/aggregative.py
+++ b/quapy/method/aggregative.py
@@ -249,7 +249,7 @@ class AggregativeQuantifier(BaseQuantifier, ABC):
 
 class AggregativeCrispQuantifier(AggregativeQuantifier, ABC):
     """
-    Abstract class for quantification methods that base their estimations on the aggregation of crips decisions
+    Abstract class for quantification methods that base their estimations on the aggregation of crisp decisions
     as returned by a hard classifier. Aggregative crisp quantifiers thus extend Aggregative
     Quantifiers by implementing specifications about crisp predictions.
     """

--- a/setup.py
+++ b/setup.py
@@ -123,10 +123,9 @@ setup(
     #
     # Similar to `install_requires` above, these must be valid existing
     # projects.
-    # extras_require={  # Optional
-    #     'dev': ['check-manifest'],
-    #     'test': ['coverage'],
-    # },
+    extras_require={  # Optional
+       'bayes': ['jax', 'jaxlib', 'numpyro'],
+    },
 
     # If there are data files included in your packages that need to be
     # installed, specify them here.


### PR DESCRIPTION
Hi Alex,

In #27 we discussed two threads: other solvers for ACC/PCC (such as BBSE or invariant ratio estimators) and [Bayesian quantification](https://arxiv.org/abs/2302.09159).

This PR sketches how the Bayesian quantification estimator could look like. Instead of solving an equation (by explicit inversion or optimization), it uses a Markov chain Monte Carlo [NUTS sampler](https://jmlr.org/papers/volume15/hoffman14a/hoffman14a.pdf) to find all prevalence vector values $P_\text{test}(Y)$ compatible with the observed distribution of classifier predictions.
More formally, we are doing Bayesian inference in the following model:
![image](https://github.com/HLT-ISTI/QuaPy/assets/26385111/477e3e9f-4196-4465-82cc-5fe2889873ed)
![image](https://github.com/HLT-ISTI/QuaPy/assets/26385111/0c8e3a9b-d933-4f35-955f-1a00a38e8687)

where $\pi'$ is the latent variable modelling $P_\text{test}(Y)$ and $\phi$ is a latent variable modelling $P(C\mid Y)$ matrix (where $C$ is the classifier prediction and $Y$ is the true label).