### PR TITLE
Invariant ratio estimators and documentation for Bayesian quantification

### DIFF
--- a/examples/bayesian_quantification.py
+++ b/examples/bayesian_quantification.py
@@ -35,6 +35,7 @@ FIGURE_PATH = "bayesian_quantification.pdf"
 
 @dataclass
 class SimulatedData:
+    """Auxiliary class to keep the training and test data sets."""
     n_classes: int
     X_train: np.ndarray
     Y_train: np.ndarray
@@ -44,13 +45,16 @@ class SimulatedData:
 
 def simulate_data(rng) -> SimulatedData:
     """Generates a simulated data set with three classes."""
-    cov = np.eye(2)
 
+    # Number of examples of each class in both data sets
     n_train = [400, 400, 400]
     n_test = [40, 25, 15]
 
+    # Mean vectors and shared covariance of P(X|Y) distributions
     mus = [np.zeros(2), np.array([1, 1.5]), np.array([1.5, 1])]
+    cov = np.eye(2)
     
+    # Generate the features accordingly
     X_train = np.concatenate([
         rng.multivariate_normal(mus[i], cov, size=n_train[i])
         for i in range(3)
@@ -95,6 +99,8 @@ def plot_simulated_data(axs, data: SimulatedData) -> None:
         ax.set_aspect("equal")
         ax.set_xlim(*xlim)
         ax.set_ylim(*ylim)
+        ax.set_xticks([])
+        ax.set_yticks([])
 
     ax = axs[0]
     ax.set_title("Training set")
@@ -110,10 +116,14 @@ def plot_simulated_data(axs, data: SimulatedData) -> None:
     ax.set_title("Test set\n(as observed)")
     ax.scatter(data.X_test[:, 0], data.X_test[:, 1], c="C5", s=3, rasterized=True)
 
+
 def get_random_forest() -> RandomForestClassifier:
+    """An auxiliary factory method to generate a random forest."""
     return RandomForestClassifier(n_estimators=10, random_state=5)    
 
+
 def train_and_plot_bayesian_quantification(ax: plt.Axes, training: LabelledCollection, test: np.ndarray, n_classes: int) -> None:
+    """Fits Bayesian quantification and plots posterior mean as well as individual samples"""
     quantifier = BayesianCC(classifier=get_random_forest())
     quantifier.fit(training)
 
@@ -129,9 +139,11 @@ def train_and_plot_bayesian_quantification(ax: plt.Axes, training: LabelledColle
 
 
 def _get_estimate(estimator_class, training: LabelledCollection, test: np.ndarray) -> None:
+    """Auxiliary method for running ACC and PACC."""
     estimator = estimator_class(get_random_forest())
     estimator.fit(training)
     return estimator.quantify(test)
+
 
 def train_and_plot_acc(ax: plt.Axes, training: LabelledCollection, test: np.ndarray, n_classes: int) -> None:
     estimate = _get_estimate(ACC, training, test)
@@ -144,6 +156,7 @@ def train_and_plot_pacc(ax: plt.Axes, training: LabelledCollection, test: np.nda
 
 
 def plot_true_proportions(ax: plt.Axes, test_labels: np.ndarray, n_classes: int) -> None:
+    """Plots the true proportions."""
     counts = np.bincount(test_labels, minlength=n_classes)
     proportion = counts / counts.sum()
     

--- a/examples/bayesian_quantification.py
+++ b/examples/bayesian_quantification.py
@@ -1,0 +1,189 @@
+"""
+This example shows how to use Bayesian quantification (https://arxiv.org/abs/2302.09159),
+which is suitable for low-data situations and when the uncertainty of the prevalence estimate is of interest.
+
+For this, we will need to install extra dependencies:
+
+```
+$ pip install quapy[bayesian]
+```
+
+Running the script via:
+
+```
+$ python examples/bayesian_quantification.py
+```
+
+will produce a plot `bayesian_quantification.pdf`.
+
+Due to a low sample size and the fact that classes 2 and 3 are hard to distinguish,
+it is hard to estimate the proportions accurately, what is visible by looking at the posterior samples,
+showing large uncertainty.
+"""
+from dataclasses import dataclass
+
+import numpy as np
+import matplotlib.pyplot as plt
+
+from sklearn.ensemble import RandomForestClassifier
+
+from quapy.method.aggregative import BayesianCC, ACC, PACC
+from quapy.data import LabelledCollection
+
+FIGURE_PATH = "bayesian_quantification.pdf"
+
+
+@dataclass
+class SimulatedData:
+    n_classes: int
+    X_train: np.ndarray
+    Y_train: np.ndarray
+    X_test: np.ndarray
+    Y_test: np.ndarray
+
+
+def simulate_data(rng) -> SimulatedData:
+    """Generates a simulated data set with three classes."""
+    cov = np.eye(2)
+
+    n_train = [400, 400, 400]
+    n_test = [40, 25, 15]
+
+    mus = [np.zeros(2), np.array([1, 1.5]), np.array([1.5, 1])]
+    
+    X_train = np.concatenate([
+        rng.multivariate_normal(mus[i], cov, size=n_train[i])
+        for i in range(3)
+    ])
+    
+    X_test = np.concatenate([
+        rng.multivariate_normal(mus[i], cov, size=n_test[i])
+        for i in range(3)
+    ])
+
+    Y_train = np.concatenate([[i] * n for i, n in enumerate(n_train)])
+    Y_test = np.concatenate([[i] * n for i, n in enumerate(n_test)])
+
+    return SimulatedData(
+        n_classes=3,
+        X_train=X_train,
+        X_test=X_test,
+        Y_train=Y_train,
+        Y_test=Y_test,
+    )
+
+
+def plot_simulated_data(axs, data: SimulatedData) -> None:
+    """Plots a simulated data set.
+    
+    Args:
+        axs: a list of three `plt.Axes` objects, on which the samples will be plotted.
+        data: the simulated data set.
+    """
+    xlim = (
+        -0.3 + min(data.X_train[:, 0].min(), data.X_test[:, 0].min()),
+        0.3 + max(data.X_train[:, 0].max(), data.X_test[:, 0].max())
+    )
+    ylim = (
+        -0.3 + min(data.X_train[:, 1].min(), data.X_test[:, 1].min()),
+        0.3 + max(data.X_train[:, 1].max(), data.X_test[:, 1].max())
+    )
+
+    for ax in axs:
+        ax.set_xlabel("$X_1$")
+        ax.set_ylabel("$X_2$")
+        ax.set_aspect("equal")
+        ax.set_xlim(*xlim)
+        ax.set_ylim(*ylim)
+
+    ax = axs[0]
+    ax.set_title("Training set")
+    for i in range(data.n_classes):
+        ax.scatter(data.X_train[data.Y_train == i, 0], data.X_train[data.Y_train == i, 1], c=f"C{i}", s=3, rasterized=True)
+
+    ax = axs[1]
+    ax.set_title("Test set\n(with labels)")
+    for i in range(data.n_classes):
+        ax.scatter(data.X_test[data.Y_test == i, 0], data.X_test[data.Y_test == i, 1], c=f"C{i}", s=3, rasterized=True)
+
+    ax = axs[2]
+    ax.set_title("Test set\n(as observed)")
+    ax.scatter(data.X_test[:, 0], data.X_test[:, 1], c="C5", s=3, rasterized=True)
+
+def get_random_forest() -> RandomForestClassifier:
+    return RandomForestClassifier(n_estimators=10, random_state=5)    
+
+def train_and_plot_bayesian_quantification(ax: plt.Axes, training: LabelledCollection, test: np.ndarray, n_classes: int) -> None:
+    quantifier = BayesianCC(classifier=get_random_forest())
+    quantifier.fit(training)
+
+    # Obtain mean prediction
+    mean_prediction = quantifier.quantify(test)
+    x_ax = np.arange(n_classes)
+    ax.plot(x_ax, mean_prediction, c="salmon", linewidth=2, linestyle=":", label="Bayesian")
+
+    # Obtain individual samples 
+    samples = quantifier.get_prevalence_samples()
+    for sample in samples[::5, :]:
+        ax.plot(x_ax, sample, c="salmon", alpha=0.1, linewidth=0.3, rasterized=True)
+
+
+def _get_estimate(estimator_class, training: LabelledCollection, test: np.ndarray) -> None:
+    estimator = estimator_class(get_random_forest())
+    estimator.fit(training)
+    return estimator.quantify(test)
+
+def train_and_plot_acc(ax: plt.Axes, training: LabelledCollection, test: np.ndarray, n_classes: int) -> None:
+    estimate = _get_estimate(ACC, training, test)
+    ax.plot(np.arange(n_classes), estimate, c="darkblue", linewidth=2, linestyle=":", label="ACC")
+
+
+def train_and_plot_pacc(ax: plt.Axes, training: LabelledCollection, test: np.ndarray, n_classes: int) -> None:
+    estimate = _get_estimate(PACC, training, test)
+    ax.plot(np.arange(n_classes), estimate, c="limegreen", linewidth=2, linestyle=":", label="PACC")
+
+
+def plot_true_proportions(ax: plt.Axes, test_labels: np.ndarray, n_classes: int) -> None:
+    counts = np.bincount(test_labels, minlength=n_classes)
+    proportion = counts / counts.sum()
+    
+    x_ax = np.arange(n_classes)
+    ax.plot(x_ax, proportion, c="black", linewidth=2, label="True")
+
+    ax.set_xlabel("Class")
+    ax.set_ylabel("Prevalence")
+    ax.set_xticks(x_ax, x_ax + 1)
+    ax.set_yticks([0, 0.25, 0.5, 0.75, 1.0])
+    ax.set_xlim(-0.1, n_classes - 0.9)
+    ax.set_ylim(-0.01, 1.01)
+
+
+
+def main() -> None:
+    # --- Simulate data ---
+    rng = np.random.default_rng(42)
+    data = simulate_data(rng)
+
+    # --- Plot simulated data ---
+    fig, axs = plt.subplots(1, 4, figsize=(13, 3), dpi=300)
+    for ax in axs:
+        ax.spines[['top', 'right']].set_visible(False)
+    plot_simulated_data(axs[:3], data)
+
+    # --- Plot quantification results ---
+    ax = axs[3]
+    plot_true_proportions(ax, test_labels=data.Y_test, n_classes=data.n_classes)
+    
+    training = LabelledCollection(data.X_train, data.Y_train)
+    train_and_plot_acc(ax, training=training, test=data.X_test, n_classes=data.n_classes)
+    train_and_plot_pacc(ax, training=training, test=data.X_test, n_classes=data.n_classes)
+    train_and_plot_bayesian_quantification(ax=ax, training=training, test=data.X_test, n_classes=data.n_classes)
+
+    ax.legend(bbox_to_anchor=(1.05, 1), loc='upper left', frameon=False)
+
+    fig.tight_layout()
+    fig.savefig(FIGURE_PATH)
+
+
+if __name__ == '__main__':
+    main()

--- a/quapy/functional.py
+++ b/quapy/functional.py
@@ -466,11 +466,12 @@ def solve_adjustment(
     if method == "inversion":
         pass  # We leave A and B unchanged
     elif method == "invariant-ratio":
-        # Change the last set of equations
-        raise NotImplementedError
+        # Change the last equation to replace
+        # it with the normalization condition
+        A[-1, :] = 1.0
+        B[-1] = 1.0
     else:
-        raise ValueError(f"Flavour {method} not known.")
-
+        raise ValueError(f"Method {method} not known.")
 
     if solver == "minimize":
         def loss(prev):

--- a/quapy/method/aggregative.py
+++ b/quapy/method/aggregative.py
@@ -435,27 +435,13 @@ class ACC(AggregativeCrispQuantifier):
         :return: an adjusted `np.ndarray` of shape `(n_classes,)` with the corrected class prevalence estimates
         """
 
-        A = PteCondEstim
-        B = prevs_estim
-
-        if solver == 'exact':
-            # attempts an exact solution of the linear system (may fail)
-
-            try:
-                adjusted_prevs = np.linalg.solve(A, B)
-                adjusted_prevs = F.clip_prevalence(adjusted_prevs, method="clip")
-            except np.linalg.LinAlgError:
-                adjusted_prevs = prevs_estim  # no way to adjust them!
-
-            return adjusted_prevs
-
-        elif solver == 'minimize':
-            # poses the problem as an optimization one, and tries to minimize the norm of the differences
-
-            def loss(prev):
-                return np.linalg.norm(A @ prev - B)
-
-            return F.optim_minimize(loss, n_classes=A.shape[0])
+        estimate = F.solve_adjustment(
+            p_c_y=PteCondEstim,
+            p_c=prevs_estim,
+            solver=solver,
+            method='inversion',
+        )
+        return F.clip_prevalence(estimate, method="clip")
 
 
 class PCC(AggregativeSoftQuantifier):

--- a/quapy/method/aggregative.py
+++ b/quapy/method/aggregative.py
@@ -443,8 +443,7 @@ class ACC(AggregativeCrispQuantifier):
 
             try:
                 adjusted_prevs = np.linalg.solve(A, B)
-                adjusted_prevs = np.clip(adjusted_prevs, 0, 1)
-                adjusted_prevs /= adjusted_prevs.sum()
+                adjusted_prevs = F.clip_prevalence(adjusted_prevs, method="clip")
             except np.linalg.LinAlgError:
                 adjusted_prevs = prevs_estim  # no way to adjust them!
 


### PR DESCRIPTION
Hi Alex,

Wow, you merged #28  it so quickly! Thanks a lot :slightly_smiling_face: 
Regarding #27, I added the invariant ratio estimators of [Vaz et al. (2018)](https://jmlr.org/papers/v20/18-456.html). The matrix they invert is constructed using a general mapping from instances to $\mathbb R^L$, by building a matrix of shape $(L-1) \times L$ (by using only $L-1$ outputs) and adding as the $L$th equation the constraint $p_1 + \cdots + p_L = 1$.

For example, it can be the conditional confusion matrix $P(C\mid Y)$ for a classifier, restricted to the first $L-1$ outputs, constructed in "hard" (ACC) or "soft" (PACC) manner, so I added it accordingly. I refactored the code, so that this choice is decoupled from the solver used.

Additionally, now the clipping is configurable: the default method is still clipping to $(0, 1)$ and normalizing, but Vaz et al. use projection onto a simplex and call it the "restricted invariant ratio estimator".

Overall this PR turned out to implement a more changes than expected, so apologies if it's hard to review! Please, let me know if changes to it are needed or how to submit PRs targeted at wiki (my understanding is that the Sphinx docstrings go to developer API, but not to the wiki, am I right?)

With many thanks and best wishes,
Pawel

## Overview of changes
- The routine for solving a system of equations is now in `quapy.functional`.
- It supports invariant ratio estimators. The choice is decoupled from the solver used.
- Both ACC and PCC support different methods of clipping.
- To show how #28 works in practice, I added a small demo (see below).


## Demonstration of Bayesian quantification
A tiny artificial data set (a mixture of three overlapping Gaussians) doesn't allow precise quantification, what is reflected in the posterior:
![image](https://github.com/HLT-ISTI/QuaPy/assets/26385111/aeb2a803-fdc0-4379-a4a2-b90e801f111f)
