### PR TITLE
Fix ThresholdOptimization: should support `predict_proba`

### DIFF
--- a/quapy/method/_threshold_optim.py
+++ b/quapy/method/_threshold_optim.py
@@ -32,6 +32,16 @@ class ThresholdOptimization(BinaryAggregativeQuantifier):
         self.val_split = val_split
         self.n_jobs = qp._get_njobs(n_jobs)
 
+    def _classifier_method(self):
+        """
+        Name of the method that must be used for issuing label predictions. If the classifier uses "predict_proba" (i.e.,
+        the standard method name for scikit-learn soft predictions), this will be used. Otherwise, the default
+        "decision_function" for AggregativeQuantifier will be used.
+
+        :return: string
+        """
+        return 'predict_proba' if hasattr(self.classifier, 'predict_proba') else 'decision_function'
+
     @abstractmethod
     def condition(self, tpr, fpr) -> float:
         """

--- a/quapy/method/_threshold_optim.py
+++ b/quapy/method/_threshold_optim.py
@@ -5,10 +5,10 @@ from sklearn.base import BaseEstimator
 import quapy as qp
 import quapy.functional as F
 from quapy.data import LabelledCollection
-from quapy.method.aggregative import BinaryAggregativeQuantifier
+from quapy.method.aggregative import AggregativeSoftQuantifier, BinaryAggregativeQuantifier
 
 
-class ThresholdOptimization(BinaryAggregativeQuantifier):
+class ThresholdOptimization(AggregativeSoftQuantifier, BinaryAggregativeQuantifier):
     """
     Abstract class of Threshold Optimization variants for :class:`ACC` as proposed by
     `Forman 2006 <https://dl.acm.org/doi/abs/10.1145/1150402.1150423>`_ and
@@ -93,7 +93,7 @@ class ThresholdOptimization(BinaryAggregativeQuantifier):
     def aggregate_with_threshold(self, classif_predictions, tprs, fprs, thresholds):
         # This function performs the adjusted count for given tpr, fpr, and threshold.
         # Note that, due to broadcasting, tprs, fprs, and thresholds could be arrays of length > 1
-        prevs_estims = np.mean(classif_predictions[:, None] >= thresholds, axis=0)
+        prevs_estims = np.mean(classif_predictions[:, 1][:, np.newaxis] >= np.asarray(thresholds), axis=0)
         prevs_estims = (prevs_estims - fprs) / (tprs - fprs)
         prevs_estims = F.as_binary_prevalence(prevs_estims, clip_if_necessary=True)
         return prevs_estims.squeeze()

--- a/quapy/method/_threshold_optim.py
+++ b/quapy/method/_threshold_optim.py
@@ -74,6 +74,7 @@ class ThresholdOptimization(BinaryAggregativeQuantifier):
         :param y: predicted labels for the validation set (or for the training set via `k`-fold cross validation)
         :return: best `tpr` and `fpr` and `threshold` according to `_condition`
         """
+        decision_scores = decision_scores[:, self.pos_label] if decision_scores.ndim > 1 else decision_scores
         candidate_thresholds = np.unique(decision_scores)
 
         candidates = []
@@ -103,7 +104,8 @@ class ThresholdOptimization(BinaryAggregativeQuantifier):
     def aggregate_with_threshold(self, classif_predictions, tprs, fprs, thresholds):
         # This function performs the adjusted count for given tpr, fpr, and threshold.
         # Note that, due to broadcasting, tprs, fprs, and thresholds could be arrays of length > 1
-        prevs_estims = np.mean(classif_predictions[:, 1][:, np.newaxis] >= np.asarray(thresholds), axis=0)
+        classif_predictions = classif_predictions[:, self.pos_label] if classif_predictions.ndim > 1 else classif_predictions
+        prevs_estims = np.mean(classif_predictions[:, np.newaxis] >= np.asarray(thresholds), axis=0)
         prevs_estims = (prevs_estims - fprs) / (tprs - fprs)
         prevs_estims = F.as_binary_prevalence(prevs_estims, clip_if_necessary=True)
         return prevs_estims.squeeze()

--- a/quapy/method/_threshold_optim.py
+++ b/quapy/method/_threshold_optim.py
@@ -5,10 +5,10 @@ from sklearn.base import BaseEstimator
 import quapy as qp
 import quapy.functional as F
 from quapy.data import LabelledCollection
-from quapy.method.aggregative import AggregativeSoftQuantifier, BinaryAggregativeQuantifier
+from quapy.method.aggregative import BinaryAggregativeQuantifier
 
 
-class ThresholdOptimization(AggregativeSoftQuantifier, BinaryAggregativeQuantifier):
+class ThresholdOptimization(BinaryAggregativeQuantifier):
     """
     Abstract class of Threshold Optimization variants for :class:`ACC` as proposed by
     `Forman 2006 <https://dl.acm.org/doi/abs/10.1145/1150402.1150423>`_ and


### PR DESCRIPTION
I think all the `ThresholdOptimization` based methods should be a sub-class of `AggregativeSoftQuantifier`, as they require the decision_scores (posterior probabilities) issued by the classifier.