### PR TITLE
val_split in pcc

### DIFF
--- a/quapy/method/aggregative.py
+++ b/quapy/method/aggregative.py
@@ -402,8 +402,8 @@ class PCC(AggregativeSoftQuantifier):
     :param classifier: a sklearn's Estimator that generates a classifier
     """
 
-    def __init__(self, classifier: BaseEstimator = None, fit_classifier: bool = True):
-        super().__init__(classifier, fit_classifier, val_split=None)
+    def __init__(self, classifier: BaseEstimator = None, fit_classifier: bool = True, val_split=None):
+        super().__init__(classifier, fit_classifier, val_split=val_split)
 
     def aggregation_fit(self, classif_predictions, labels):
         """


### PR DESCRIPTION
PCC quantifier does not have a val_split parameter in its constructor, unlike all other *CC quantifiers.
This prevents setting the number of splits for validation in PCC and inconveniently breaks the code when multiple *CC are tested setting the val_split parameter.