### PR TITLE
removed true_divide warning

### DIFF
--- a/quapy/functional.py
+++ b/quapy/functional.py
@@ -277,7 +277,7 @@ def l1_norm(prevalences: ArrayLike) -> np.ndarray:
     """
     n_classes = prevalences.shape[-1]
     accum = prevalences.sum(axis=-1, keepdims=True)
-    prevalences = np.true_divide(prevalences, accum, where=accum > 0)
+    prevalences = np.true_divide(prevalences, accum, where=accum > 0, out=None)
     allzeros = accum.flatten() == 0
     if any(allzeros):
         if prevalences.ndim == 1:


### PR DESCRIPTION
true_divide used with the where argument and out implicity set to None print a warning about the values of the newly create data structure returned as output to have uninitialized value for the indexes that are excluded by the where clause.
Explicitly setting out=None removes the warning.
The issue with uninitialized values is covered by the successive part of the code that set uniform distribution for the classes with accum==0.