### PR TITLE
Fix regex for whitespace delimiter in CSV reads

### DIFF
--- a/quapy/data/datasets.py
+++ b/quapy/data/datasets.py
@@ -486,7 +486,7 @@ def fetch_UCIBinaryLabelledCollection(dataset_name, data_home=None, standardize=
         # fall back to direct download when needed
         if group == "german":
             with download_tmp_file("statlog/german", "german.data-numeric") as tmp:
-                df = pd.read_csv(tmp, header=None, delim_whitespace=True)
+                df = pd.read_csv(tmp, header=None, sep="\\s+")
             X, y = df.iloc[:, 0:24].astype(float).values, df[24].astype(int).values
         elif group == "ctg":
             with download_tmp_file("00193", "CTG.xls") as tmp:
@@ -500,7 +500,7 @@ def fetch_UCIBinaryLabelledCollection(dataset_name, data_home=None, standardize=
             y = df["NSP"].astype(int).values
         elif group == "semeion":
             with download_tmp_file("semeion", "semeion.data") as tmp:
-                df = pd.read_csv(tmp, header=None, sep='\s+')
+                df = pd.read_csv(tmp, header=None, sep="\\s+")
             X = df.iloc[:, 0:256].astype(float).values
             y = df[263].values  # 263 stands for digit 8 (labels are one-hot vectors from col 256-266)
         else:


### PR DESCRIPTION
This pull request makes minor updates to the way whitespace-separated data files are read in the `download` function of `quapy/data/datasets.py`. The changes standardize the `sep` parameter in `pd.read_csv` calls to use a raw string for whitespace separation.

Data loading consistency:

* Removed deprecated `delim_whitespace` and updated the `sep` argument in `pd.read_csv` to use `sep="\\s+"` (a properly escaped string for whitespace separation) for both the "german" and "semeion" dataset loading cases in `quapy/data/datasets.py`. [[1]](diffhunk://#diff-4ec757357d413757b8c3ee05ab220c8fa16c371096a55b27bdb76fed6a24106cL489-R489) [[2]](diffhunk://#diff-4ec757357d413757b8c3ee05ab220c8fa16c371096a55b27bdb76fed6a24106cL503-R503)